### PR TITLE
[#2] add default settings local conf

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -1,9 +1,11 @@
 header:
   version: 18
-
+  includes:
+    - local.yml
 repos:
   meta-rust-bin:
     url: https://github.com/rust-embedded/meta-rust-bin.git
     branch: master
+
   ../meta-iceoryx2:
 

--- a/kas/local.yml
+++ b/kas/local.yml
@@ -1,0 +1,22 @@
+header:
+  version: 18
+
+local_conf_header:
+  base: |
+    CONF_VERSION = "2"
+    SOURCE_MIRROR_URL = "http://downloads.yoctoproject.org/mirror/sources/"
+    INHERIT += "buildstats buildstats-summary buildhistory"
+    INHERIT += "report-error"
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+    USER_CLASSES ?= "buildstats"
+
+  diskmon: |
+    BB_DISKMON_DIRS ??= "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        HALT,${TMPDIR},100M,1K \
+        HALT,${DL_DIR},100M,1K \
+        HALT,${SSTATE_DIR},100M,1K \
+        HALT,/tmp,10M,1K"


### PR DESCRIPTION
The current kas setup lacking of some basic setting from `local.conf`. This adding the setting from default template https://git.yoctoproject.org/poky/tree/meta-poky/conf/templates/default/local.conf.sample?h=scarthgap  to kas yml.

Tested with running via `kas shell meta-iceoryx2/kas/scarthgap.yml -c 'runqemu kvm nographic'`

user: `root`
default password: `root`

<img width="713" height="242" alt="image" src="https://github.com/user-attachments/assets/f3a46f1e-6e96-4500-945f-2fc028e4db95" />
