### PR TITLE
[#36] Make ptest fail fast

### DIFF
--- a/recipes-iceoryx2/iceoryx2-bb-cxx/iceoryx2-bb-cxx/run-ptest
+++ b/recipes-iceoryx2/iceoryx2-bb-cxx/iceoryx2-bb-cxx/run-ptest
@@ -18,4 +18,5 @@ if ./tests/iceoryx2-bb-cxx-tests ; then
     echo "PASS: iceoryx2-bb-cxx-tests"
 else
     echo "FAIL: iceoryx2-bb-cxx-tests"
+    exit 1
 fi

--- a/recipes-iceoryx2/iceoryx2-bb-cxx/iceoryx2-bb-cxx_git.bb
+++ b/recipes-iceoryx2/iceoryx2-bb-cxx/iceoryx2-bb-cxx_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2-c-examples/iceoryx2-c-examples_git.bb
+++ b/recipes-iceoryx2/iceoryx2-c-examples/iceoryx2-c-examples_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2-c/iceoryx2-c_git.bb
+++ b/recipes-iceoryx2/iceoryx2-c/iceoryx2-c_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2-cmake-modules/iceoryx2-cmake-modules_git.bb
+++ b/recipes-iceoryx2/iceoryx2-cmake-modules/iceoryx2-cmake-modules_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2-cxx-examples/iceoryx2-cxx-examples_git.bb
+++ b/recipes-iceoryx2/iceoryx2-cxx-examples/iceoryx2-cxx-examples_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2-cxx/iceoryx2-cxx/run-ptest
+++ b/recipes-iceoryx2/iceoryx2-cxx/iceoryx2-cxx/run-ptest
@@ -18,4 +18,5 @@ if ./tests/iceoryx2-cxx-tests ; then
     echo "PASS: iceoryx2-cxx-tests"
 else
     echo "FAIL: iceoryx2-cxx-tests"
+    exit 1
 fi

--- a/recipes-iceoryx2/iceoryx2-cxx/iceoryx2-cxx_git.bb
+++ b/recipes-iceoryx2/iceoryx2-cxx/iceoryx2-cxx_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite.inc
+++ b/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite.inc
@@ -57,7 +57,7 @@ do_install_ptest() {
     for test in ${CARGO_BINDIR}/deps/*; do
         if [ -f "$test" ] && [ -x "$test" ] && [ "${test##*.}" != "so" ]; then
             case "$test" in
-                *benchmark*|*component-tests_rust*|iox2-*|*macro*|*tunnel_end_to_end*|*nostd*) continue ;;
+                *benchmark*|*component-tests_rust*|*examples_common*|*iox2-*|*iox2_*|*nostd*|*tunnel_end_to_end*|*win32*) continue ;;
             esac
             install -m 0755 "$test" ${D}/${PTEST_PATH}/tests
         fi

--- a/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite/run-ptest
+++ b/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite/run-ptest
@@ -13,6 +13,9 @@
 
 export RUST_TEST_THREADS=1
 
+# there are some tests which are using quite a lot of file descriptors and hit the 1024 open FD limit
+ulimit -n 2048
+
 for test in ./tests/* 
 do
     if ${test} ; then

--- a/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite/run-ptest
+++ b/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite/run-ptest
@@ -19,5 +19,6 @@ do
         echo "PASS: ${test}"
     else
         echo "FAIL: ${test}"
+        exit 1
     fi
 done

--- a/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite_git.bb
+++ b/recipes-iceoryx2/iceoryx2/iceoryx2-validation-suite_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"

--- a/recipes-iceoryx2/iceoryx2/iceoryx2_git.bb
+++ b/recipes-iceoryx2/iceoryx2/iceoryx2_git.bb
@@ -1,3 +1,3 @@
 require ${BPN}.inc
 
-SRCREV = "8d20af8dc164c11e129092530bdd43a068c2d0d2"
+SRCREV = "9b4dedb0deeba7218266502008c9b654a1d9ea71"


### PR DESCRIPTION
This PR makes ptest fail fast if a test fails. Additionally, tests which are not supposed to be executed on Yocto are removed from the packaging and the file descriptor limit is increased to make some tests pass.